### PR TITLE
use 'read -s' to read secret instead of 'read'

### DIFF
--- a/generate-proof-of-win-private-key.sh
+++ b/generate-proof-of-win-private-key.sh
@@ -87,7 +87,7 @@ echo -n "  🙋 Your Pub Key (SS58) for $NETWORK = $ADDRESS"
 echo "  🙈 Your  provided secret is hashed for you by the script,"
 echo "     not exposed in the output.\n"
 echo "  🏆 Your prize secret (three words, space separated):"
-read SECRET
+read -s SECRET
 
 # debug, uncomment to override:
 # SECRET="some thee words"

--- a/generate-proof-of-win-signature.sh
+++ b/generate-proof-of-win-signature.sh
@@ -96,7 +96,7 @@ read PUB
 echo "  🙈 Your  provided secret is hashed for you by the script,"
 echo "     not exposed in the output.\n"
 echo "  🏆 Your prize secret (three words, space separated):"
-read SECRET
+read -s SECRET
 
 # debug, uncomment to override:
 # SECRET="some thee words"


### PR DESCRIPTION
Use 'read -s' to read secret without echoing characters on the screen to avoid exposing private information during a script execution